### PR TITLE
18 - Add basic governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
+*   @waddella @gmbecker

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+Thank you for your interest in contributing to this repo!
+
+Here are a few things you can do that will increase the likelihood of your pull
+request being accepted:
+
+- Ensure that the pull request is associated with an existing Github issue. If not, create a new issue that is associated with this change.
+- Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
+- Complete the checklist and description while creating the pull request.
+- Write good commit messages.

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,53 @@
+---
+name: Bug report
+about: Let us know about an unexpected error, a crash, or an incorrect behavior.
+labels: bug
+
+---
+
+<!--
+Hi there,
+
+Thank you for opening an issue.
+-->
+
+### Reproduction case
+
+<!--
+To fix problems, we need clear reproduction cases - we need to be able to see it happen locally. A reproduction case is ideally something that anyone can git-clone or copy-paste and run immediately, without inventing any details or context. 
+
+A short example can be directly copy-pasteable; longer examples should be in separate a Github gist, or git repositories especially if multiple files are needed
+-->
+
+
+### sessionInfo() output
+
+<!--
+The output of sessionInfo(), so that we may emulate a similar environment to reproduce the issue.
+-->
+
+```R
+# sessionInfo()
+```
+
+### Expected Behavior
+<!--
+What should have happened?
+-->
+
+### Actual Behavior
+<!--
+What actually happened?
+-->
+
+### Additional Context
+<!--
+Are there anything atypical about your situation that we should know? For example, whether are you running this in a Docker container and the image that was used.
+-->
+
+### References
+<!--
+Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here? For example:
+
+- #419
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,61 @@
+---
+name: Feature request
+about: Suggest a new feature or other enhancement.
+labels: enhancement
+
+---
+
+<!--
+Hi! Thank you for opening an issue. Please note that we try to keep the issue tracker reserved for bug reports and feature requests.
+-->
+
+### Current package version
+<!---
+Which version of the package are you currently using? We will try to evaluate whether the feature you are existing already exists in the version you are using or whether this request is on the roadmap in a future release.
+-->
+
+```
+...
+```
+
+### Use-cases
+<!---
+In order to properly evaluate a feature request, it is necessary to understand the use-cases for it.
+
+Please describe below the _end goal_ you are trying to achieve that has led you to request this feature.
+
+Please keep this section focused on the problem and not on the suggested solution. We'll get to that in a moment, below!
+-->
+
+
+
+### Attempted Solutions
+<!---
+If you've already tried to solve the problem within this package's existing features and found a limitation that prevented you from succeeding, please describe it below in as much detail as possible.
+
+Ideally, this would include real code snippets that you tried to run, and what results you got in each case.
+
+Please remove any sensitive information before sharing code snippets.
+--->
+
+```R
+# code
+```
+
+### Proposal
+<!---
+If you have an idea for a way to address the problem via a change to Terraform features, please describe it below.
+
+In this section, it's helpful to include specific examples of how what you are suggesting might look in actual code, since that allows us to understand the full picture of what you are proposing.
+
+If you're not sure of some details, don't worry! When we evaluate the feature request we may suggest modifications as necessary to work within the design and architectural contraints of this package.
+-->
+
+
+
+### References
+<!--
+Are there any other GitHub issues, whether open or closed, that are related to the problem you've described above or to the suggested solution? If so, please create a list below that mentions each of them. For example:
+
+- #68
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+<!-- Thank you for your contribution! -->
+
+## Checklist
+
+- [] My pull request is linked to a Github issue
+- [] I have reviewed the Contribution guidelines
+
+## Description
+
+<!-- Please describe your pull request -->


### PR DESCRIPTION
Tracks Issue #18 

Add boilerplate governance standards for folks who want to contribute to the project. 

Features included:

1. Bug and Feature Request templates when creating new issues. 
2. Code Owners who will be automatically added as reviewers when a new PR is created. This provides us with the ability to merge PRs _only_ after the PR has been approved by one or more code owners. 
3. Basic contribution guidelines.
4. A simple PR template to allow contributors to make sure that they are abiding by the governance standards set herein. 

Refer to additional branch-protection related governance settings here: https://github.com/Roche/respectables/settings/branch_protection_rules/20730306